### PR TITLE
testing; don't embed interface in implementation

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -15,7 +15,6 @@ import (
 
 /* TestMilter object */
 type TestMilter struct {
-	Milter
 	multipart bool
 	message   *bytes.Buffer
 }
@@ -32,6 +31,8 @@ func (e *TestMilter) Disconnect() {
 func (e *TestMilter) Connect(name, value string, port uint16, ip net.IP, m *Modifier) (Response, error) {
 	return RespContinue, nil
 }
+
+func (e *TestMilter) Helo(h string, m *Modifier) (Response, error) { return RespContinue, nil }
 
 func (e *TestMilter) MailFrom(name string, m *Modifier) (Response, error) {
 	return RespContinue, nil


### PR DESCRIPTION
Embedding the interface type inside an implementation is fragile, it
means the implementation will satisfy the interface even when it
doesn't implement all the methods (this can result nil-pointer
crashes).